### PR TITLE
Replacing fasthash

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 #        python-version: ["3.7", "3.8", "3.9", "3.10"]
         python-version: ["3.7", "3.10"]
         exclude:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,38 +27,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "fasthash"
-version = "0.4.0"
+name = "getrandom"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "032213946b4eaae09117ec63f020322b78ca7a31d8aa2cf64df3032e1579690f"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
- "cfg-if 0.1.10",
- "fasthash-sys",
- "num-traits",
- "seahash",
- "xoroshiro128",
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi",
 ]
-
-[[package]]
-name = "fasthash-sys"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6de941abfe2e715cdd34009d90546f850597eb69ca628ddfbf616e53dda28f8"
-dependencies = [
- "gcc",
-]
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
-name = "gcc"
-version = "0.3.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 
 [[package]]
 name = "indoc"
@@ -117,12 +94,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "mur3"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97af489e1e21b68de4c390ecca6703318bc1aa16e9733bcb62c089b73c6fbb1b"
+
+[[package]]
 name = "narrow_down"
 version = "0.1.0"
 dependencies = [
- "fasthash",
+ "mur3",
  "numpy",
  "pyo3",
+ "twox-hash",
 ]
 
 [[package]]
@@ -231,6 +215,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,46 +294,49 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.4.6"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
- "fuchsia-cprng",
  "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
 ]
 
 [[package]]
-name = "rand_core"
+name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
- "rand_core 0.4.2",
+ "ppv-lite86",
+ "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.4.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
+dependencies = [
+ "rand_core",
+]
 
 [[package]]
 name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
-]
 
 [[package]]
 name = "redox_syscall"
@@ -361,26 +354,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
-name = "seahash"
-version = "3.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f57ca1d128a43733fd71d583e837b1f22239a37ebea09cde11d8d9a9080f47"
-
-[[package]]
 name = "smallvec"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 
 [[package]]
-name = "syn"
-version = "1.0.84"
+name = "static_assertions"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecb2e6da8ee5eb9a61068762a32fa9619cc591ceb055b3687f4cd4051ec2e06b"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "syn"
+version = "1.0.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a684ac3dcd8913827e18cd09a68384ee66c1de24157e3c556c9ab16d85695fb7"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "twox-hash"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee73e6e4924fe940354b8d4d98cad5231175d615cd855b758adc658c0aac6a0"
+dependencies = [
+ "cfg-if 1.0.0",
+ "rand",
+ "static_assertions",
 ]
 
 [[package]]
@@ -394,6 +398,12 @@ name = "unindent"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f14ee04d9415b52b3aeab06258a3f07093182b88ba0f9b8d203f211a7a7d41c7"
+
+[[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "winapi"
@@ -416,12 +426,3 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "xoroshiro128"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0eeda34baec49c4f1eb2c04d59b761582fd6330010f9330ca696ca1a355dfcd"
-dependencies = [
- "rand",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ path = "rust/lib.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-fasthash = "0.4.0"
+twox-hash = "1.6.2"
+mur3 = "0.1.0"
 numpy = "0.15.0"
 pyo3 = { version = "0.15.1", features = ["extension-module", "abi3-py37"] }

--- a/noxfile.py
+++ b/noxfile.py
@@ -32,7 +32,14 @@ def install_with_constraints(session: Session, *args: str) -> None:  # noqa
 def tests(session: Session) -> None:
     """Run the test suite."""
     install_with_constraints(
-        session, "invoke", "pytest", "xdoctest", "coverage[toml]", "pytest-asyncio", "pytest-cov"
+        session,
+        "invoke",
+        "pytest",
+        "xdoctest",
+        "coverage[toml]",
+        "pytest-asyncio",
+        "pytest-benchmark",
+        "pytest-cov",
     )
     try:
         session.run(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ dev = [
 "bump2version~=1.0",
 "pytest~=6.2",
 "pytest-asyncio",
+"pytest-benchmark",
 "xdoctest~=0.15",
 "coverage[toml]~=6.0",
 "pytest-cov~=3.0",

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -1,35 +1,41 @@
-use fasthash::{murmur3, xx};
 use numpy::PyReadonlyArray1;
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
+use std::hash::Hasher;
+use twox_hash::XxHash32;
+use twox_hash::XxHash64;
 
 const MERSENNE_PRIME: u32 = 4294967295u32; // mersenne prime (1 << 32) - 1
 
-enum HashAlgorithm {
-    Murmur3_32bit,
-    Xxhash32bit,
-    Xxhash64bit,
-}
+// enum HashAlgorithm {
+//     Murmur3_32bit,
+//     Xxhash32bit,
+//     Xxhash64bit,
+// }
 
 /// murmur3_32bit(s: bytes) -> int
 /// Calculate the 32 bit murmur3 hash of the input string.
 #[pyfunction]
 fn murmur3_32bit(s: &[u8]) -> u32 {
-    murmur3::hash32(s)
+    mur3::murmurhash3_x86_32(s, 0)
 }
 
 /// xxhash_32bit(s: bytes) -> int
 /// Calculate the 32 bit xxhash of the input string.
 #[pyfunction]
 fn xxhash_32bit(s: &[u8]) -> u32 {
-    xx::hash32(s)
+    let mut h = XxHash32::with_seed(0);
+    h.write(s);
+    h.finish().try_into().unwrap()
 }
 
 /// xxhash_64bit(s: bytes) -> int
 /// Calculate the 64 bit xxhash of the input string.
 #[pyfunction]
 fn xxhash_64bit(s: &[u8]) -> u64 {
-    xx::hash64(s)
+    let mut h = XxHash64::with_seed(0);
+    h.write(s);
+    h.finish()
 }
 
 #[pyfunction]
@@ -43,7 +49,10 @@ fn minhash<'py>(
     assert_eq!(b.ndim(), 1);
     assert_eq!(a.shape()[0], b.shape()[0]);
 
-    let murmur_hashes: Vec<u32> = shingle_list.iter().map(|s| murmur3_32bit(s.as_bytes())).collect();
+    let murmur_hashes: Vec<u32> = shingle_list
+        .iter()
+        .map(|s| murmur3_32bit(s.as_bytes()))
+        .collect();
     let mut minhashes: Vec<u32> = Vec::new();
     let a_slice = a.as_slice()?;
     let b_slice = b.as_slice()?;
@@ -68,11 +77,9 @@ fn _rust(_py: Python, m: &PyModule) -> PyResult<()> {
     Ok(())
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use numpy::IntoPyArray;
 
     // Test hashes from https://asecuritysite.com/hash/smh
     #[test]
@@ -94,6 +101,7 @@ mod tests {
     }
 
     // // This needs linking to libpython and doesn't work with cargo test:
+    // use numpy::IntoPyArray;
     // #[test]
     // fn test_minhash() {
     //     Python::with_gil(|py|{

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -43,7 +43,7 @@ fn minhash<'py>(
     assert_eq!(b.ndim(), 1);
     assert_eq!(a.shape()[0], b.shape()[0]);
 
-    let murmur_hashes: Vec<u32> = shingle_list.iter().map(|s| murmur3::hash32(s)).collect();
+    let murmur_hashes: Vec<u32> = shingle_list.iter().map(|s| murmur3_32bit(s.as_bytes())).collect();
     let mut minhashes: Vec<u32> = Vec::new();
     let a_slice = a.as_slice()?;
     let b_slice = b.as_slice()?;
@@ -72,23 +72,36 @@ fn _rust(_py: Python, m: &PyModule) -> PyResult<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use numpy::IntoPyArray;
 
     // Test hashes from https://asecuritysite.com/hash/smh
     #[test]
     fn test_murmur3_32bit() {
-        assert_eq!(murmur3_32bit("test"), 3127628307u32);
-        assert_eq!(murmur3_32bit(""), 0u32);
+        assert_eq!(murmur3_32bit(b"test"), 3127628307u32);
+        assert_eq!(murmur3_32bit(b""), 0u32);
     }
 
     #[test]
     fn test_xxhash_32bit() {
-        assert_eq!(xxhash_32bit("test"), 1042293711u32);
-        assert_eq!(xxhash_32bit(""), 46947589u32);
+        assert_eq!(xxhash_32bit(b"test"), 1042293711u32);
+        assert_eq!(xxhash_32bit(b""), 46947589u32);
     }
 
     #[test]
     fn test_xxhash_64bit() {
-        assert_eq!(xxhash_64bit("test"), 5754696928334414137u64);
-        assert_eq!(xxhash_64bit(""), 17241709254077376921u64);
+        assert_eq!(xxhash_64bit(b"test"), 5754696928334414137u64);
+        assert_eq!(xxhash_64bit(b""), 17241709254077376921u64);
     }
+
+    // // This needs linking to libpython and doesn't work with cargo test:
+    // #[test]
+    // fn test_minhash() {
+    //     Python::with_gil(|py|{
+    //         let shingles = vec!["abc", "def"];
+    //         let a = vec![1608637543u32, 3421126068u32].into_pyarray(py);
+    //         let b = vec![4083286876u32,  787846414u32].into_pyarray(py);
+    //         let mh = minhash(py, shingles, a.readonly(), b.readonly());
+    //         assert_eq!(mh.unwrap(), vec![530362422u32, 32829942u32]);
+    //     });
+    // }
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,34 @@
+"""Common fixtures for the test modules."""
+import pytest
+
+
+@pytest.fixture
+def sample_byte_strings():
+    """Return a list of byte arbitrary byte strings."""
+    return [
+        b"QHtbc3lzdGVtICJ0b3VjaCAvdG1wL2JsbnMuZmFpbCJdfQ==",
+        b"ZXZhbCgicHV0cyAnaGVsbG8gd29ybGQnIik=",
+        b"U3lzdGVtKCJscyAtYWwgLyIp",
+        b"YGxzIC1hbCAvYA==",
+        b"S2VybmVsLmV4ZWMoImxzIC1hbCAvIik=",
+        b"S2VybmVsLmV4aXQoMSk=",
+        b"JXgoJ2xzIC1hbCAvJyk=",
+        b"PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iSVNPLTg4NTktMSI/PjwhRE9DVFlQRSBmb28g",
+        b"WyA8IUVMRU1FTlQgZm9vIEFOWSA+PCFFTlRJVFkgeHhlIFNZU1RFTSAiZmlsZTovLy9ldGMvcGFz",
+        b"c3dkIiA+XT48Zm9vPiZ4eGU7PC9mb28+",
+        b"JEhPTUU=",
+        b"JEVOVnsnSE9NRSd9",
+        b"true",
+        b"false",
+        b"-1.00",
+        b"-$1.00",
+        b"-1/2",
+        b"-1E2",
+        b"0/0",
+        b"-2147483648/-1",
+        b"-9223372036854775808/-1",
+        b"-0",
+        b"-0.0",
+        b"+0",
+        b"+0.0",
+    ]

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -1,4 +1,6 @@
 """Tests for `narrow_down.hash`."""
+import pytest
+
 from narrow_down import hash
 
 
@@ -15,3 +17,42 @@ def test_xxhash_32bit():
 def test_xxhash_64bit():
     assert hash.xxhash_64bit("test".encode("utf-8")) == 5754696928334414137
     assert hash.xxhash_64bit("".encode("utf-8")) == 17241709254077376921
+
+
+SAMPLE_BYTE_STRINGS = [
+    b"QHtbc3lzdGVtICJ0b3VjaCAvdG1wL2JsbnMuZmFpbCJdfQ==",
+    b"ZXZhbCgicHV0cyAnaGVsbG8gd29ybGQnIik=",
+    b"U3lzdGVtKCJscyAtYWwgLyIp",
+    b"YGxzIC1hbCAvYA==",
+    b"S2VybmVsLmV4ZWMoImxzIC1hbCAvIik=",
+    b"S2VybmVsLmV4aXQoMSk=",
+    b"JXgoJ2xzIC1hbCAvJyk=",
+    b"PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iSVNPLTg4NTktMSI/PjwhRE9DVFlQRSBmb28g",
+    b"WyA8IUVMRU1FTlQgZm9vIEFOWSA+PCFFTlRJVFkgeHhlIFNZU1RFTSAiZmlsZTovLy9ldGMvcGFz",
+    b"c3dkIiA+XT48Zm9vPiZ4eGU7PC9mb28+",
+    b"JEhPTUU=",
+    b"JEVOVnsnSE9NRSd9",
+    b"true",
+    b"false",
+    b"-1.00",
+    b"-$1.00",
+    b"-1/2",
+    b"-1E2",
+    b"0/0",
+    b"-2147483648/-1",
+    b"-9223372036854775808/-1",
+    b"-0",
+    b"-0.0",
+    b"+0",
+    b"+0.0",
+]
+
+
+@pytest.mark.parametrize("hashfunction", [hash.murmur3_32bit, hash.xxhash_32bit, hash.xxhash_64bit])
+def test_hashfunction_benchmark(benchmark, hashfunction):
+    def f():
+        return list(map(hashfunction, SAMPLE_BYTE_STRINGS))[-1]
+
+    result = benchmark(f)
+
+    assert isinstance(result, int)

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -19,39 +19,10 @@ def test_xxhash_64bit():
     assert hash.xxhash_64bit("".encode("utf-8")) == 17241709254077376921
 
 
-SAMPLE_BYTE_STRINGS = [
-    b"QHtbc3lzdGVtICJ0b3VjaCAvdG1wL2JsbnMuZmFpbCJdfQ==",
-    b"ZXZhbCgicHV0cyAnaGVsbG8gd29ybGQnIik=",
-    b"U3lzdGVtKCJscyAtYWwgLyIp",
-    b"YGxzIC1hbCAvYA==",
-    b"S2VybmVsLmV4ZWMoImxzIC1hbCAvIik=",
-    b"S2VybmVsLmV4aXQoMSk=",
-    b"JXgoJ2xzIC1hbCAvJyk=",
-    b"PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iSVNPLTg4NTktMSI/PjwhRE9DVFlQRSBmb28g",
-    b"WyA8IUVMRU1FTlQgZm9vIEFOWSA+PCFFTlRJVFkgeHhlIFNZU1RFTSAiZmlsZTovLy9ldGMvcGFz",
-    b"c3dkIiA+XT48Zm9vPiZ4eGU7PC9mb28+",
-    b"JEhPTUU=",
-    b"JEVOVnsnSE9NRSd9",
-    b"true",
-    b"false",
-    b"-1.00",
-    b"-$1.00",
-    b"-1/2",
-    b"-1E2",
-    b"0/0",
-    b"-2147483648/-1",
-    b"-9223372036854775808/-1",
-    b"-0",
-    b"-0.0",
-    b"+0",
-    b"+0.0",
-]
-
-
 @pytest.mark.parametrize("hashfunction", [hash.murmur3_32bit, hash.xxhash_32bit, hash.xxhash_64bit])
-def test_hashfunction_benchmark(benchmark, hashfunction):
+def test_hashfunction_benchmark(benchmark, sample_byte_strings, hashfunction):
     def f():
-        return list(map(hashfunction, SAMPLE_BYTE_STRINGS))[-1]
+        return list(map(hashfunction, sample_byte_strings))[-1]
 
     result = benchmark(f)
 

--- a/tests/test_minhash.py
+++ b/tests/test_minhash.py
@@ -8,11 +8,26 @@ from narrow_down import _minhash, data_types, storage
 def test_minhash():
     """Check minhashing of a document with hand-checked result."""
     mh = _minhash.MinHasher(2, 42)
+    print(mh.a)
+    print(mh.b)
     minhashes = mh.minhash(["abc", "def", "g"])
 
     assert minhashes.shape == (2,)
     assert minhashes.dtype == np.uint32
     assert (minhashes == np.array([530362422, 32829942], dtype=np.uint32)).all()
+
+
+def test_minhash_benchmark(benchmark, sample_byte_strings):
+    sample_strings = [s.decode("utf-8") for s in sample_byte_strings]
+
+    def f():
+        mh = _minhash.MinHasher(64, 42)
+        return list(map(mh.minhash, sample_strings))[-1]
+
+    minhashes = benchmark(f)
+
+    assert minhashes.dtype == np.uint32
+    assert minhashes.shape == (64,)
 
 
 @pytest.mark.asyncio

--- a/tests/test_minhash.py
+++ b/tests/test_minhash.py
@@ -8,8 +8,6 @@ from narrow_down import _minhash, data_types, storage
 def test_minhash():
     """Check minhashing of a document with hand-checked result."""
     mh = _minhash.MinHasher(2, 42)
-    print(mh.a)
-    print(mh.b)
     minhashes = mh.minhash(["abc", "def", "g"])
 
     assert minhashes.shape == (2,)


### PR DESCRIPTION
Fasthash doesn't compile on windows and Mac, so it is replaced with hash implementations which work on all platforms.