### PR TITLE
Option to remove documents from the index

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,13 @@
 
-name: release
+name: "build & release"
 
 on:
   push:
     tags:
       - 'v*'
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:
@@ -113,6 +116,7 @@ jobs:
   test-release:
     runs-on: ubuntu-latest
     needs: [ test-install ]
+    if: "github.event_name != 'pull_request'"
     steps:
       - uses: actions/download-artifact@v2
         with:
@@ -127,7 +131,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    if: "startsWith(github.ref, 'refs/tags/')"
+    if: "github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/')"
     needs: [ test-install, test-release ]
     steps:
       - uses: actions/download-artifact@v2
@@ -145,6 +149,7 @@ jobs:
   github_release:
     needs: release
     name: Create Github Release
+    if: "github.event_name != 'pull_request'"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
+### Added
+- Documents can now be removed from the index again with SimilarityStore.remove_by_id()
 
 ## [0.2.1] - 2022-01-09
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,5 +77,5 @@ On branch "main":
 
 - Adjust CHANGELOG.md as described on [https://keepachangelog.com](https://keepachangelog.com).
 - Then run `invoke version [major | minor | patch]`. This updates the version numbers and creates a tagged commit.
-- Push the commit to github: `git push --tags`
+- Push the commit to github: `git push origin main && git push --tags`
 - A github action will automatically create a github release and publish to pypi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,7 +101,7 @@ checksum = "97af489e1e21b68de4c390ecca6703318bc1aa16e9733bcb62c089b73c6fbb1b"
 
 [[package]]
 name = "narrow_down"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "mur3",
  "numpy",

--- a/narrow_down/_minhash.py
+++ b/narrow_down/_minhash.py
@@ -11,7 +11,7 @@ import numpy.typing as npt
 from scipy.integrate import quad as integrate
 
 from . import _rust, hash
-from .data_types import Fingerprint, StorageLevel, StoredDocument
+from .data_types import Fingerprint, StorageLevel, StoredDocument, TooLowStorageLevel
 from .storage import StorageBackend
 
 _MERSENNE_PRIME = np.uint32((1 << 32) - 1)
@@ -124,6 +124,8 @@ class LSH:
 
         Raises:
             KeyError: If no document with the given ID is stored.
+            TooLowStorageLevel: If the fingerprints needed to find the document in the
+                LSH structure are not available.
         """
         try:
             doc = StoredDocument.deserialize(
@@ -133,15 +135,16 @@ class LSH:
             if check_if_exists:
                 raise
             return
-        if doc.fingerprint is not None:
-            for band_number in range(self.n_bands):  # TODO: parallelize
-                start_index = band_number * self.rows_per_band
-                h = self._hash(
-                    doc.fingerprint[start_index : start_index + self.rows_per_band], doc.exact_part
-                )
-                await self._storage.remove_id_from_bucket(
-                    bucket_id=band_number, document_hash=h, document_id=document_id
-                )
+        if doc.fingerprint is None:
+            raise TooLowStorageLevel("Fingerprint needed to remove a document from the LSH!")
+        for band_number in range(self.n_bands):  # TODO: parallelize
+            start_index = band_number * self.rows_per_band
+            h = self._hash(
+                doc.fingerprint[start_index : start_index + self.rows_per_band], doc.exact_part
+            )
+            await self._storage.remove_id_from_bucket(
+                bucket_id=band_number, document_hash=h, document_id=document_id
+            )
         await self._storage.remove_document(document_id=document_id)
 
     async def query(

--- a/narrow_down/_minhash.py
+++ b/narrow_down/_minhash.py
@@ -115,6 +115,35 @@ class LSH:
             )
         return doc_index
 
+    async def remove_by_id(self, document_id: int, check_if_exists: bool = False) -> None:
+        """Remove the document with the given ID from the internal data structures.
+
+        Args:
+            document_id: ID of the document to remove.
+            check_if_exists: Raise a KeyError if the document does not exist.
+
+        Raises:
+            KeyError: If no document with the given ID is stored.
+        """
+        try:
+            doc = StoredDocument.deserialize(
+                await self._storage.query_document(document_id), document_id
+            )
+        except KeyError:
+            if check_if_exists:
+                raise
+            return
+        if doc.fingerprint is not None:
+            for band_number in range(self.n_bands):  # TODO: parallelize
+                start_index = band_number * self.rows_per_band
+                h = self._hash(
+                    doc.fingerprint[start_index : start_index + self.rows_per_band], doc.exact_part
+                )
+                await self._storage.remove_id_from_bucket(
+                    bucket_id=band_number, document_hash=h, document_id=document_id
+                )
+        await self._storage.remove_document(document_id=document_id)
+
     async def query(
         self, fingerprint: Fingerprint, *, exact_part: str = None
     ) -> Collection[StoredDocument]:

--- a/narrow_down/data_types.py
+++ b/narrow_down/data_types.py
@@ -9,6 +9,10 @@ import numpy as np
 from numpy import typing as npt
 
 
+class TooLowStorageLevel(Exception):
+    """Raised if a feature is used for which a higher storage level is needed."""
+
+
 class StorageLevel(enum.Flag):  # TODO: Review name
     """Detail level of document persistence."""
 
@@ -68,7 +72,7 @@ class StoredDocument:
             attributes: The names of the attributes to leave empty
 
         Returns:
-            A copy of the StoredDocument with all the attributes specified in *attributes left out.
+            A copy of the StoredDocument with all the attributes specified in attributes left out.
             So they will have their default value (None).
         """
         return StoredDocument(

--- a/tests/test_similarity_store.py
+++ b/tests/test_similarity_store.py
@@ -1,6 +1,7 @@
 """Tests for `narrow_down.similarity_store`."""
 import pytest
 
+import narrow_down.data_types
 from narrow_down.data_types import StorageLevel
 from narrow_down.similarity_store import SimilarityStore
 
@@ -29,3 +30,45 @@ async def test_similarity_store__insert_and_query_with_default_settings(storage_
         assert list(results)[0].document == sample_doc
     else:
         assert list(results)[0].document is None
+
+
+@pytest.mark.asyncio
+async def test_similarity_store__remove_by_id():
+    simstore = SimilarityStore(storage_level=StorageLevel.Fingerprint)
+    await simstore.initialize()
+    sample_doc = "Some example document"
+
+    doc_id = await simstore.insert(sample_doc)
+    await simstore.remove_by_id(doc_id)
+    await simstore.remove_by_id(doc_id + 1, check_if_exists=False)
+    results = await simstore.query(sample_doc)
+
+    assert list(results) == []
+
+
+@pytest.mark.asyncio
+async def test_similarity_store__remove_by_id__error_storage_level():
+    simstore = SimilarityStore(storage_level=StorageLevel.Minimal)
+    await simstore.initialize()
+    sample_doc = "Some example document"
+
+    doc_id = await simstore.insert(sample_doc)
+    with pytest.raises(narrow_down.data_types.TooLowStorageLevel):
+        await simstore.remove_by_id(doc_id)
+    results = await simstore.query(sample_doc)
+
+    assert len(results) == 1
+
+
+@pytest.mark.asyncio
+async def test_similarity_store__remove_by_id__key_error():
+    simstore = SimilarityStore(storage_level=StorageLevel.Fingerprint)
+    await simstore.initialize()
+    sample_doc = "Some example document"
+
+    doc_id = await simstore.insert(sample_doc)
+    with pytest.raises(KeyError):
+        await simstore.remove_by_id(doc_id + 1, check_if_exists=True)
+    results = await simstore.query(sample_doc)
+
+    assert len(results) == 1


### PR DESCRIPTION
With SimilarityStore.remove_by_id() documents can be removed from the storage again. It only works if the storage level is high enough, otherwise an exception is raised.