### PR TITLE
Fixing the parameter order for lsh configs in SimilarityStore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
+### Fixed
+- Wrong order of parameters for Minhash LSH in the SimilarityStore class
 
 ## [0.3.0] - 2022-01-09
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,7 +101,7 @@ checksum = "97af489e1e21b68de4c390ecca6703318bc1aa16e9733bcb62c089b73c6fbb1b"
 
 [[package]]
 name = "narrow_down"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "mur3",
  "numpy",

--- a/narrow_down/similarity_store.py
+++ b/narrow_down/similarity_store.py
@@ -45,7 +45,7 @@ class SimilarityStore:
         lsh_config = _minhash.find_optimal_config(
             jaccard_threshold=similarity_threshold,
             max_false_negative_proba=max_false_negative_proba,
-            max_false_positive_proba=max_false_negative_proba,
+            max_false_positive_proba=max_false_positive_proba,
         )
         self._minhash = _minhash.MinHasher(n_hashes=lsh_config.n_hashes)
         self._lsh = _minhash.LSH(lsh_config, storage=self._storage)

--- a/narrow_down/similarity_store.py
+++ b/narrow_down/similarity_store.py
@@ -43,7 +43,9 @@ class SimilarityStore:
         self._tokenize = tokenize or (lambda s: _tokenize.word_ngrams(s, n=3))
         # TODO: What about a setup with an existing database?
         lsh_config = _minhash.find_optimal_config(
-            max_false_negative_proba, max_false_positive_proba, similarity_threshold
+            jaccard_threshold=similarity_threshold,
+            max_false_negative_proba=max_false_negative_proba,
+            max_false_positive_proba=max_false_negative_proba,
         )
         self._minhash = _minhash.MinHasher(n_hashes=lsh_config.n_hashes)
         self._lsh = _minhash.LSH(lsh_config, storage=self._storage)


### PR DESCRIPTION
The parameters:

- max_false_negative_proba
- max_false_positive_proba
- similarity_threshold
        
were passed in wrong order to the underlying Minhash LSH,
