### PR TITLE
Fix minhash integer overflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - StoredDocument objects are now serialized with protobuf to increase speed and reduce storage
   consumption.
 
+### Fixed
+- Integer overflows in the minhash calculation which reduced the quality of the permutations
+  (hash functions). Depending on the input effectively max_uint32 was used instead of a prime number 
+  in the modulo calculation.
+
 ## [0.5.0] - 2022-01-17
 ### Changed
 - The SQLite backends take now an init parameter "partitions" which leads to internally

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -81,7 +81,7 @@ fn _rust(_py: Python, m: &PyModule) -> PyResult<()> {
 mod tests {
     use super::*;
 
-    // More an educational test, but not harmful. We relly on u32::MAX being a prime number.
+    // More an educational test, but not harmful. We rely on u32::MAX being a prime number.
     #[test]
     fn test_mersenne_prime() {
         assert_eq!(MERSENNE_PRIME, (1 << 32) - 1);

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -5,7 +5,7 @@ use std::hash::Hasher;
 use twox_hash::XxHash32;
 use twox_hash::XxHash64;
 
-const MERSENNE_PRIME: u64 = 4294967295u64; // mersenne prime (1 << 32) - 1
+const MERSENNE_PRIME: u64 = u32::MAX as u64; // mersenne prime (1 << 32) - 1
 
 // enum HashAlgorithm {
 //     Murmur3_32bit,
@@ -80,6 +80,12 @@ fn _rust(_py: Python, m: &PyModule) -> PyResult<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // More an educational test, but not harmful. We relly on u32::MAX being a prime number.
+    #[test]
+    fn test_mersenne_prime() {
+        assert_eq!(MERSENNE_PRIME, (1 << 32) - 1);
+    }
 
     // Test hashes from https://asecuritysite.com/hash/smh
     #[test]

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -5,7 +5,7 @@ use std::hash::Hasher;
 use twox_hash::XxHash32;
 use twox_hash::XxHash64;
 
-const MERSENNE_PRIME: u32 = 4294967295u32; // mersenne prime (1 << 32) - 1
+const MERSENNE_PRIME: u64 = 4294967295u64; // mersenne prime (1 << 32) - 1
 
 // enum HashAlgorithm {
 //     Murmur3_32bit,
@@ -49,9 +49,9 @@ fn minhash<'py>(
     assert_eq!(b.ndim(), 1);
     assert_eq!(a.shape()[0], b.shape()[0]);
 
-    let murmur_hashes: Vec<u32> = shingle_list
+    let murmur_hashes: Vec<u64> = shingle_list
         .iter()
-        .map(|s| murmur3_32bit(s.as_bytes()))
+        .map(|s| murmur3_32bit(s.as_bytes()) as u64)
         .collect();
     let mut minhashes: Vec<u32> = Vec::new();
     let a_slice = a.as_slice()?;
@@ -59,9 +59,9 @@ fn minhash<'py>(
     for (a_i, b_i) in a_slice.iter().zip(b_slice) {
         let minhash: u32 = murmur_hashes
             .iter()
-            .map(|h| (a_i * h + b_i) % MERSENNE_PRIME)
+            .map(|h| u64::from(*a_i) * h + u64::from(*b_i) % MERSENNE_PRIME)// TODO
             .min()
-            .unwrap_or(MERSENNE_PRIME);
+            .unwrap_or(MERSENNE_PRIME) as u32;
         minhashes.push(minhash);
     }
     Ok(minhashes)

--- a/tests/test_minhash.py
+++ b/tests/test_minhash.py
@@ -18,7 +18,7 @@ def test_minhash():
 
     assert minhashes.shape == (2,)
     assert minhashes.dtype == np.uint32
-    assert (minhashes == np.array([530362422, 32829942], dtype=np.uint32)).all()
+    assert (minhashes == np.array([2439865586, 4085789398], dtype=np.uint32)).all()
 
 
 def test_minhash_benchmark(benchmark, sample_byte_strings):


### PR DESCRIPTION
Fixing integer overflows in the minhash calculation which reduced the quality of the permutations (hash functions). Depending on the input effectively max_uint32 was used instead of a prime number in the modulo calculation.

The critical part was
```
(a_i * h + b_i) % MERSENNE_PRIME)
```
where a_i, h, b_i are uint32 and MERSENNE_PRIME is (1 << 32) - 1 ( which is u32::MAX also). This will often already overflow in the multiplication and then the modulo operation effectively happens before the addition.