### PR TITLE
store "exact_part" with document

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,11 +13,11 @@ repos:
   hooks:
     - id: isort
 - repo: https://github.com/psf/black
-  rev: 21.12b0
+  rev: 22.1.0
   hooks:
     - id: black
 - repo: https://github.com/asottile/blacken-docs
-  rev: v1.12.0
+  rev: v1.12.1
   hooks:
     - id: blacken-docs
       additional_dependencies: ["black==21.12b0"]

--- a/narrow_down/data_types.py
+++ b/narrow_down/data_types.py
@@ -98,7 +98,7 @@ class StoredDocument:
 
 _FIELDS_FOR_STORAGE_LEVEL = {
     StorageLevel.Minimal: {"data"},
-    StorageLevel.Document: {"data", "document"},
+    StorageLevel.Document: {"data", "document", "exact_part"},
     StorageLevel.Fingerprint: {"data", "exact_part"},
     StorageLevel.Full: {"data", "document", "exact_part"},
 }

--- a/narrow_down/scylladb.py
+++ b/narrow_down/scylladb.py
@@ -201,7 +201,7 @@ class ScyllaDBStore(StorageBackend):
                 return document_id
             else:
                 for _ in range(10):
-                    doc_id = random.randint(a=0, b=2 ** 32)
+                    doc_id = random.randint(a=0, b=2**32)
                     result = await self._execute(
                         session,
                         self._prepared_statements["set_doc_checked"],

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -16,7 +16,7 @@ from narrow_down.data_types import Fingerprint, StorageLevel, StoredDocument
     "storage_level, expected_fields",
     [
         (StorageLevel.Minimal, {"data"}),
-        (StorageLevel.Document, {"data", "document"}),
+        (StorageLevel.Document, {"data", "document", "exact_part"}),
         (StorageLevel.Fingerprint, {"data", "exact_part", "fingerprint"}),
         (StorageLevel.Full, {"data", "document", "exact_part", "fingerprint"}),
     ],


### PR DESCRIPTION
When the storage level is set to "document" the exact_part was not stored, but only if the storage level is "fingerprint".
However, it is a usecase to use the document together with the exact_part for evaluation of search hits. 