### PR TITLE
Implement validation of similarity thresholds at query time

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,14 +41,15 @@ Narrow Down offers a flexible but easy-to-use Python API to finding duplicates o
 
 ## Installation
 The Python package can be installed with *pip*:
-
-  pip install narrow-down
+```shell
+pip install narrow-down
+```
 
 ### Extras
 
 Some of the heavier functionality is available as *extra*:
 ```shell
-  pip install narrow-down[scylladb]   # Cassandra / ScyllaDB storage backend
+pip install narrow-down[scylladb]   # Cassandra / ScyllaDB storage backend
 ```
 
 ## Similar projects

--- a/docs/user_guide/similarity_store.md
+++ b/docs/user_guide/similarity_store.md
@@ -17,8 +17,8 @@ Here we choose the [StorageLevel](narrow_down.data_types.StorageLevel) `Document
 >>> similarity_store = asyncio.run(
 ...     nd.similarity_store.SimilarityStore.create(
 ...         storage_level=nd.data_types.StorageLevel.Document,
-...         similarity_threshold=0.8,
-...         tokenize="char_ngrams(5)",
+...         similarity_threshold=0.75,
+...         tokenize="char_ngrams(3)",
 ...     )
 ... )
 
@@ -51,7 +51,7 @@ Now the object can be filled with documents. As example reviews of a popular oat
 ...     "Love these cookies especially for the kids",
 ...     "My kids loved them.",
 ...     "Lunchbox or Work Staple",
-...     "So Delious",
+...     "So Delious as no other",
 ...     "Over-Packaged Product",
 ...     "yum",
 ...     "Great taste",
@@ -74,21 +74,12 @@ Now that the some data is indexed, the SimilarityStore is ready to execute searc
 >>> search_result == [StoredDocument(id_=13, document="awesome cookies")]
 True
 
->>> search_result = asyncio.run(similarity_store.query("So Delicious".lower()))
->>> search_result == []
+>>> search_result = asyncio.run(similarity_store.query("So Delicious as no other".lower()))
+>>> search_result == [StoredDocument(id_=24, document="so delious as no other")]
 True
 
->>> search_result = asyncio.run(similarity_store.query("Awesome!".lower()))
->>> search_result == [StoredDocument(id_=13, document="awesome cookies")]
-True
-
->>> search_result = asyncio.run(similarity_store.query("Like Homemade!".lower()))
->>> search_result == [
-...     StoredDocument(
-...         id_=18,
-...         document="good, but not homemade.",
-...     )
-... ]
+>>> search_result = asyncio.run(similarity_store.query("Very, very good cookie".lower()))
+>>> search_result == [StoredDocument(id_=20, document="very good cookie")]
 True
 
 >>> search_result = asyncio.run(similarity_store.query("Loving every bit of it!".lower()))

--- a/narrow_down/similarity_store.py
+++ b/narrow_down/similarity_store.py
@@ -1,7 +1,7 @@
 """High-level API for indexing and retrieval of documents."""
 import re
 import warnings
-from typing import Callable, Collection, Union
+from typing import Callable, Collection, Iterable, Union
 
 from narrow_down import _minhash, _tokenize
 from narrow_down._minhash import MinhashLshConfig
@@ -14,6 +14,7 @@ class SimilarityStore:
 
     __slots__ = (
         "_minhasher",
+        "_similarity_threshold",
         "_lsh",
         "_storage",
         "_storage_level",
@@ -29,6 +30,7 @@ class SimilarityStore:
             "SimilarityStore.create() or SimilarityStore.load_from_storage()."
         )
         self._minhasher: _minhash.MinHasher
+        self._similarity_threshold: float
         self._lsh: _minhash.LSH
         self._storage: StorageBackend
         self._storage_level: StorageLevel
@@ -89,7 +91,7 @@ class SimilarityStore:
           # noqa: DAR101 max_false_positive_proba
           # noqa: DAR101 similarity_threshold
         """
-        obj = await cls._create_object_base(storage, storage_level, tokenize)
+        obj = await cls._create_object_base(storage, storage_level, similarity_threshold, tokenize)
         obj._lsh_config = _minhash.find_optimal_config(
             jaccard_threshold=similarity_threshold,
             max_false_negative_proba=max_false_negative_proba,
@@ -122,6 +124,10 @@ class SimilarityStore:
             # Let it throw TypeError if None:
             int(await storage.query_setting("storage_level"))  # type: ignore
         )
+        similarity_threshold = float(
+            # Let it throw TypeError if None:
+            await storage.query_setting("similarity_threshold")  # type: ignore
+        )
         tokenize_spec: Union[
             str, Callable[[str], Collection[str]], None
         ] = await storage.query_setting("tokenize")
@@ -137,6 +143,7 @@ class SimilarityStore:
         simstore = await cls._create_object_base(
             storage=storage,
             storage_level=storage_level,
+            similarity_threshold=similarity_threshold,
             tokenize=tokenize_spec,
         )
         simstore._lsh_config = lsh_config
@@ -145,11 +152,14 @@ class SimilarityStore:
         return simstore
 
     @classmethod
-    async def _create_object_base(cls, storage, storage_level, tokenize) -> "SimilarityStore":
-        """Create a new SimilarityStore object with storage, storage_level and tokenize set."""
+    async def _create_object_base(
+        cls, storage, storage_level, similarity_threshold, tokenize
+    ) -> "SimilarityStore":
+        """Create a new SimilarityStore object with the given attributes."""
         obj = SimilarityStore.__new__(cls)
         obj._storage = storage or InMemoryStore()
         obj._storage_level = storage_level
+        obj._similarity_threshold = similarity_threshold
         if isinstance(tokenize, str) or tokenize is None:
             obj._tokenize = tokenize or "word_ngrams(3)"
             obj._tokenize_callable = obj._get_tokenize_callable(obj._tokenize)
@@ -193,6 +203,7 @@ class SimilarityStore:
         existing database.
         """
         await self._storage.initialize()
+        await self._storage.insert_setting("similarity_threshold", str(self._similarity_threshold))
         await self._storage.insert_setting("storage_level", str(self._storage_level.value))
         await self._storage.insert_setting("tokenize", self._tokenize)
         await self._storage.insert_setting("lsh_config", self._lsh_config.to_json())
@@ -244,12 +255,17 @@ class SimilarityStore:
             )
         await self._lsh.remove_by_id(document_id, check_if_exists)
 
-    async def query(self, document: str, *, exact_part=None) -> Collection[StoredDocument]:
+    async def query(
+        self, document: str, *, exact_part=None, validate: bool = None
+    ) -> Collection[StoredDocument]:
         """Query all similar documents.
 
         Args:
-            document: A document to search similar items for.
+            document: A document for which to search similar items.
             exact_part: Part that should be exactly matched.
+            validate: Whether to validate if the results are really above the similarity threshold.
+                This is only possible if the storage level is at least "Document". Per default
+                validation is done if the data is available, otherwise not.
 
         Returns:
             A List of :obj:`~narrow_down.data_types.StoredDocument` objects with all elements
@@ -257,22 +273,54 @@ class SimilarityStore:
         """
         tokens = self._tokenize_callable(document)
         fingerprint = self._minhasher.minhash(tokens)
-        return await self._lsh.query(fingerprint=fingerprint, exact_part=exact_part)
+        candidates = await self._lsh.query(fingerprint=fingerprint, exact_part=exact_part)
+        if (self._storage_level & StorageLevel.Document) and validate is not False:
+            candidates = self._filter_candidates(candidates, tokens, exact_part)
+        return candidates
+
+    def _filter_candidates(self, candidates, tokens, exact_part):
+        """Filter out candidates below the similarity threshold and sort by similarity."""
+        candidates = list(filter(lambda c: c.exact_part == exact_part, candidates))
+        candidate_tokens = [set(self._tokenize_callable(c.document)) for c in candidates]
+        tokens = set(tokens)
+        true_jaccards = [_jaccard_similarity(tokens, ct) for ct in candidate_tokens]
+        candidates = [
+            c
+            for jaccard, c in sorted(zip(true_jaccards, candidates), reverse=True)
+            if jaccard >= self._similarity_threshold
+        ]
+        return list(candidates)
 
     async def query_top_n(
-        self, n: int, document: str, *, exact_part=None
+        self, n: int, document: str, *, exact_part=None, validate: bool = None
     ) -> Collection[StoredDocument]:
         """Query the top n similar documents.
 
         Args:
             n: The number of similar documents to retrieve.
-            document: A document to search similar items for.
+            document: A document for which to search similar items.
             exact_part: Part that should be exactly matched.
+            validate: Whether to validate if the results are really above the similarity threshold.
+                This is only possible if the storage level is at least "Document". Per default
+                validation is done if the data is available, otherwise not.
 
         Returns:
             A List of :obj:`~narrow_down.data_types.StoredDocument` objects with the n
             elements which are most likely above the similarity threshold.
+
+        Note that the results are probabilistic. The documents are assumed to be the most likely
+        candidates if they have the most likely fingerprint. But the actual similarity of the
+        documents themselves might differ. However, if `validate` is `True` the ordering of the
+        results is correct, because the actual documents are compared with each other.
         """
         tokens = self._tokenize_callable(document)
         fingerprint = self._minhasher.minhash(tokens)
         return await self._lsh.query_top_n(n=n, fingerprint=fingerprint, exact_part=exact_part)
+
+
+def _jaccard_similarity(s1: Iterable, s2: Iterable):
+    if not isinstance(s1, set):
+        s1 = set(s1)
+    if not isinstance(s2, set):
+        s2 = set(s2)
+    return len(s1.intersection(s2)) / len(s1.union(s2))

--- a/tests/test_backend_benchmarks.py
+++ b/tests/test_backend_benchmarks.py
@@ -80,6 +80,7 @@ def test_similarity_store__insert_25_parallel_benchmark(
     "storage_backend, storage_level",
     [
         (InMemoryStore, StorageLevel.Minimal),
+        (InMemoryStore, StorageLevel.Document),
         (ScyllaDBStore, StorageLevel.Minimal),
         (SQLiteStore, StorageLevel.Minimal),
     ],

--- a/tests/test_similarity_store.py
+++ b/tests/test_similarity_store.py
@@ -2,7 +2,7 @@
 import pytest
 
 import narrow_down.data_types
-from narrow_down.data_types import StorageLevel
+from narrow_down.data_types import StorageLevel, StoredDocument
 from narrow_down.similarity_store import SimilarityStore
 from narrow_down.sqlite import SQLiteStore
 
@@ -49,6 +49,44 @@ async def test_similarity_store__compare_query_and_query_top_1(storage_level):
     results_top_1 = await simstore.query_top_n(n=1, document=sample_doc)
 
     assert results == results_top_1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "storage_level",
+    [
+        StorageLevel.Minimal,
+        StorageLevel.Fingerprint,
+        StorageLevel.Document,
+        StorageLevel.Full,
+    ],
+)
+async def test_similarity_store__query_with_validation(monkeypatch, storage_level):
+    fake_results = [
+        StoredDocument(id_=1, document="XYZ", exact_part="A"),
+        StoredDocument(id_=2, document="ABCDEFGHIJKLMNOPQRSTUVWXYZ", exact_part="B"),
+        StoredDocument(id_=3, document="ABCDEFGHIJKLMNOPQRSTUVWXYZ1", exact_part="A"),
+        StoredDocument(id_=4, document="ABCDEFGHIJKLMNOPQRSTUVWXYZ12", exact_part="A"),
+        StoredDocument(id_=5, document="ABCDEFGHIJKLMNOPQRSTUVWXYZ", exact_part="A"),
+    ]
+
+    async def fake_query(*args, **kwargs):
+        return fake_results
+
+    simstore = await SimilarityStore.create(storage_level=storage_level, tokenize="char_ngrams(1)")
+    monkeypatch.setattr(simstore._lsh, "query", fake_query)
+
+    results = await simstore.query(document="ABCDEFGHIJKLMNOPQRSTUVWXYZ", exact_part="A")
+
+    print(results)
+    if storage_level & StorageLevel.Document:
+        assert results == [
+            StoredDocument(id_=5, document="ABCDEFGHIJKLMNOPQRSTUVWXYZ", exact_part="A"),
+            StoredDocument(id_=3, document="ABCDEFGHIJKLMNOPQRSTUVWXYZ1", exact_part="A"),
+            StoredDocument(id_=4, document="ABCDEFGHIJKLMNOPQRSTUVWXYZ12", exact_part="A"),
+        ]
+    else:
+        assert results == fake_results
 
 
 @pytest.mark.asyncio
@@ -124,6 +162,7 @@ async def test_similarity_store__insert_reload_and_query_with_custom_tokenizer(t
 @pytest.mark.asyncio
 async def test_similarity_store__load_from_storage__invalid_storage_level():
     storage = narrow_down.storage.InMemoryStore()
+    await storage.insert_setting("similarity_threshold", "0.8")
     with pytest.raises(TypeError, match=r"int\(\) argument"):
         await SimilarityStore.load_from_storage(storage)
 
@@ -132,6 +171,7 @@ async def test_similarity_store__load_from_storage__invalid_storage_level():
 async def test_similarity_store__load_from_storage__invalid_lsh_config():
     storage = narrow_down.storage.InMemoryStore()
     await storage.insert_setting("storage_level", "1")
+    await storage.insert_setting("similarity_threshold", "0.8")
     await storage.insert_setting("tokenize", "char_ngrams(3)")
     with pytest.raises(TypeError, match="lsh_config setting could not be read"):
         await SimilarityStore.load_from_storage(storage)
@@ -141,6 +181,7 @@ async def test_similarity_store__load_from_storage__invalid_lsh_config():
 async def test_similarity_store__load_from_storage__invalid_tokenize_function():
     storage = narrow_down.storage.InMemoryStore()
     await storage.insert_setting("storage_level", "1")
+    await storage.insert_setting("similarity_threshold", "0.8")
     await storage.insert_setting("lsh_config", '{"n_hashes": 0, "n_bands": 1, "rows_per_band": 2}')
     await storage.insert_setting("tokenize", "custom")
     with pytest.raises(TypeError, match="tokenize function cannot be deserialized"):


### PR DESCRIPTION
When the document is available, the actual similarity is checked and the candidates are filtered. There are no false positives then anymore.

Closes #34 