### PR TITLE
Adding table_prefix to ScyllaDBStore.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
         'flake8-bugbear~=21.9.2',
         'flake8-annotations~=2.6.2',
         'flake8-docstrings~=1.6.0',
-        'flake8-bandit~=2.1.2',
+        'flake8-bandit~=3.0.0',
         'darglint~=1.8.0'
       ]
 - repo: https://github.com/doublify/pre-commit-rust
@@ -53,7 +53,7 @@ repos:
         - -D
         - warnings
 - repo: https://github.com/nbQA-dev/nbQA
-  rev: 1.2.3
+  rev: 1.3.1
   hooks:
     - id: nbqa-isort
     - id: nbqa-black

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
+### Added
+- ScyllaDBStore now accepts a `table_prefix` setting.
+
+### Fixed
+- A use of collections.Counter as typehint broke mypy checks.  
 
 ## [0.8.0] - 2022-02-23
 ### Added

--- a/narrow_down/_minhash.py
+++ b/narrow_down/_minhash.py
@@ -7,6 +7,7 @@ import collections
 import collections.abc
 import dataclasses
 import json
+import typing
 import warnings
 from dataclasses import dataclass
 from typing import Collection, Optional
@@ -199,7 +200,7 @@ class LSH:
             tasks.append(
                 self._storage.query_ids_from_bucket(bucket_id=band_number, document_hash=h)
             )
-        candidates: collections.Counter[int] = collections.Counter()
+        candidates: typing.Counter[int] = collections.Counter()
         for new_candidates in await asyncio.gather(*tasks):
             candidates.update(new_candidates)
         return await asyncio.gather(

--- a/tests/test_scylladb.py
+++ b/tests/test_scylladb.py
@@ -209,6 +209,12 @@ async def test_scylladb_store__check_keyspace():
 
 
 @pytest.mark.asyncio
+async def test_scylladb_store__check_table_prefix():
+    with pytest.raises(ValueError):
+        narrow_down.scylladb.ScyllaDBStore(None, "keyspace", "; DROP KEYSPACE x;")
+
+
+@pytest.mark.asyncio
 async def test_scylladb_store__handle_query_error(monkeypatch, session_mock):
     from cassandra.cluster import OperationTimedOut
 


### PR DESCRIPTION
Closes #50 

## Proposed Changes
- Adding a `table_prefix` setting for ScyllaDBStore