### PR TITLE
Fixing an issue with result sorting.

### DIFF
--- a/narrow_down/similarity_store.py
+++ b/narrow_down/similarity_store.py
@@ -268,10 +268,15 @@ class SimilarityStore:
         true_jaccards = [_jaccard_similarity(tokens, ct) for ct in candidate_tokens]
         candidates = [
             c
-            for jaccard, c in sorted(zip(true_jaccards, candidates), reverse=True)
-            if jaccard >= self._similarity_threshold
+            for jaccard, c in sorted(
+                filter(
+                    lambda t: t[0] >= self._similarity_threshold, zip(true_jaccards, candidates)
+                ),
+                key=lambda t: (t[0], t[1].id_ or 0),
+                reverse=True,
+            )
         ]
-        return list(candidates)
+        return candidates
 
     async def query(
         self, document: str, *, exact_part=None, validate: bool = None

--- a/tests/test_similarity_store.py
+++ b/tests/test_similarity_store.py
@@ -72,6 +72,7 @@ async def test_similarity_store__query_with_validation(monkeypatch, storage_leve
         StoredDocument(id_=3, document="ABCDEFGHIJKLMNOPQRSTUVWXYZ1", exact_part="A"),
         StoredDocument(id_=4, document="ABCDEFGHIJKLMNOPQRSTUVWXYZ12", exact_part="A"),
         StoredDocument(id_=5, document="ABCDEFGHIJKLMNOPQRSTUVWXYZ", exact_part="A"),
+        StoredDocument(id_=6, document="ABCDEFGHIJKLMNOPQRSTUVWXYZ", exact_part="A"),
     ]
 
     async def fake_query(*args, **kwargs):
@@ -87,6 +88,7 @@ async def test_similarity_store__query_with_validation(monkeypatch, storage_leve
     print(results)
     if validate is not False and (storage_level & StorageLevel.Document):
         assert results == [
+            StoredDocument(id_=6, document="ABCDEFGHIJKLMNOPQRSTUVWXYZ", exact_part="A"),
             StoredDocument(id_=5, document="ABCDEFGHIJKLMNOPQRSTUVWXYZ", exact_part="A"),
             StoredDocument(id_=3, document="ABCDEFGHIJKLMNOPQRSTUVWXYZ1", exact_part="A"),
             StoredDocument(id_=4, document="ABCDEFGHIJKLMNOPQRSTUVWXYZ12", exact_part="A"),

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -49,6 +49,15 @@ def test_stored_document_without():
     assert document.without() is not document
 
 
+def test_stored_document_eq():
+    document1 = StoredDocument(id_=5, document="abcd")
+    document2 = StoredDocument(id_=5, document="abcd")
+    document3 = StoredDocument(id_=5, document="abcd", exact_part="abcd")
+    assert document1 == document2
+    assert document1 != document3
+    assert document2 != document3
+
+
 @pytest.mark.asyncio
 async def test_in_memory_store__insert_query_setting():
     ims = InMemoryStore()


### PR DESCRIPTION
It crashes when two documents with identical jaccard similarity are found.

Fixes #62

The reason was sorting by jaccard similarity and then by document. But there is no comparison operator for StoredDocument objects, so it couldn't work. Now the second order sorting is only by the document id.