### PR TITLE
Stricter prefiltering for query_top_n() for performance reasons

### DIFF
--- a/narrow_down/similarity_store.py
+++ b/narrow_down/similarity_store.py
@@ -327,7 +327,9 @@ class SimilarityStore:
         fingerprint = self._minhasher.minhash(tokens)
         if (self._storage_level & StorageLevel.Document) and validate is not False:
             # Query 4x the desired number to have some buffer for filtering
-            candidates = await self._lsh.query_top_n(n=n*4, fingerprint=fingerprint, exact_part=exact_part)
+            candidates = await self._lsh.query_top_n(
+                n=n * 4, fingerprint=fingerprint, exact_part=exact_part
+            )
             candidates = self._filter_candidates(candidates, tokens, exact_part)
             return candidates[:n]  # type: ignore
         return await self._lsh.query_top_n(n=n, fingerprint=fingerprint, exact_part=exact_part)


### PR DESCRIPTION
Stricter prefiltering for query_top_n() in case validate=True.
Otherwise lots of documents might be queried from the database, leading to a surprising slowdown for the users.
