### PR TITLE
Fix minhash operator precedence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Wrong operator precedence in minhash implementation, which lead to incorrect results.
+- Incorrect parsing of tokenize argument for SimilarityStore for char_ngrams without padding.
 
 ## [0.10.0] - 2022-05-08
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - minhash LSH uses the new query_documents() of the storage backends instead of running concurrent
   queries.
 
+### Fixed
+- Wrong operator precedence in minhash implementation, which lead to incorrect results.
+
 ## [0.10.0] - 2022-05-08
 ### Changed
 - Improved performance of SimilarityStore.query_top_n().

--- a/narrow_down/similarity_store.py
+++ b/narrow_down/similarity_store.py
@@ -192,7 +192,7 @@ class SimilarityStore:
                     pad_char = args[1][1:-1]
                 else:
                     pad_char = args[1]
-            if pad_char:
+            if pad_char is not None:
                 return lambda s: _tokenize.char_ngrams(s, n=n, pad_char=pad_char)
             return lambda s: _tokenize.char_ngrams(s, n=n)
         raise ValueError(f"Tokenization function not found: {tokenize_spec}")

--- a/rust/minhash.rs
+++ b/rust/minhash.rs
@@ -24,14 +24,16 @@ pub fn minhash<'py>(
     let mut minhashes: Vec<u32> = Vec::new();
     let a_slice = a.as_slice()?;
     let b_slice = b.as_slice()?;
+
     for (a_i, b_i) in a_slice.iter().zip(b_slice) {
         let minhash: u32 = murmur_hashes
             .iter()
-            .map(|h| u64::from(*a_i) * h + u64::from(*b_i) % MERSENNE_PRIME)
+            .map(|h| (u64::from(*a_i) * h + u64::from(*b_i)) % MERSENNE_PRIME)
             .min()
             .unwrap_or(MERSENNE_PRIME) as u32;
         minhashes.push(minhash);
     }
+
     Ok(minhashes)
 }
 

--- a/tests/test_minhash.py
+++ b/tests/test_minhash.py
@@ -18,7 +18,7 @@ def test_minhash():
 
     assert minhashes.shape == (2,)
     assert minhashes.dtype == np.uint32
-    assert (minhashes == np.array([2439865586, 4085789398], dtype=np.uint32)).all()
+    assert (minhashes == np.array([2048153058, 2194504465], dtype=np.uint32)).all()
 
 
 def test_minhash_benchmark(benchmark, sample_byte_strings):
@@ -38,16 +38,19 @@ def test_minhash_benchmark(benchmark, sample_byte_strings):
 async def test_lsh__basic_lookup_without_exact_part():
     """Minimal check if an LSH can be constructed."""
     test_doc = StoredDocument(
-        # document="abc def",
         exact_part="exact:part",
-        # data="some custom payload",
-        fingerprint=storage.Fingerprint(np.array([2, 4, 6])),
+        fingerprint=storage.Fingerprint(np.array([2 * i for i in range(1, 22)])),
+    )
+    unrelated_doc = StoredDocument(
+        exact_part="exact:part",
+        fingerprint=storage.Fingerprint(np.array([3 * i for i in range(0, 21)])),
     )
     lsh = _minhash.LSH(
         _minhash.MinhashLshConfig(n_hashes=2, n_bands=2, rows_per_band=1),
         storage=await storage.InMemoryStore().initialize(),
     )
     await lsh.insert(test_doc.without("exact_part"))
+    await lsh.insert(unrelated_doc.without("exact_part"))
     result = await lsh.query(test_doc.fingerprint)
     print(result)
     assert len(result) == 1


### PR DESCRIPTION
### Fixed
- Wrong operator precedence in minhash implementation, which lead to incorrect results.
- Incorrect parsing of tokenize argument for SimilarityStore for char_ngrams without padding.