### PR TITLE
Clean up CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,12 +69,6 @@ jobs:
           python3 -m pip install --upgrade pip maturin
           task develop
 
-      - name: Pylint
-        shell: bash
-        run: |
-          source ./venv/bin/activate
-          task pylint
-
       - name: Run mypy
         shell: bash
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -179,11 +179,6 @@ jobs:
         shell: bash
         run: nox --verbose --force-color -s tests-${{ matrix.python-version }}
 
-      - name: Run safety check
-        if: matrix.python-version == '3.10' && matrix.os == 'ubuntu-latest'
-        shell: bash
-        run: nox --force-color -s safety
-
       - name: Upload coverage data
         if: ${{ matrix.publish-results && always() }}
         uses: actions/upload-artifact@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,58 +1,36 @@
+ci:
+  autofix_prs: false
+  autoupdate_schedule: monthly
+  skip: []
+  submodules: false
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.4.0
   hooks:
-    - id: check-toml
-    - id: check-yaml
-    - id: debug-statements
-    - id: check-merge-conflict
-    - id: check-json
-    - id: end-of-file-fixer
-- repo: https://github.com/timothycrosley/isort
-  rev: 5.12.0
+  - id: check-merge-conflict
+  - id: check-json
+  - id: check-toml
+  - id: check-yaml
+    args: [--unsafe]
+  - id: debug-statements
+  - id: detect-private-key
+  - id: end-of-file-fixer
+- repo: https://github.com/charliermarsh/ruff-pre-commit
+  rev: 'v0.0.263'
   hooks:
-    - id: isort
-- repo: https://github.com/psf/black
-  rev: 22.12.0
+    - id: ruff
+      args: [ --fix, --exit-non-zero-on-fix ]
+- repo: https://github.com/pre-commit/mirrors-isort
+  rev: v5.10.1
   hooks:
-    - id: black
-- repo: https://github.com/asottile/blacken-docs
-  rev: v1.12.1
+  - id: isort
+- repo: https://github.com/ambv/black
+  rev: 23.3.0
   hooks:
-    - id: blacken-docs
-      additional_dependencies: ["black==22.3.0"]
-- repo: local
-  hooks:
-    - id: flakeheaven
-      name: flakeheaven
-      entry: flakeheaven
-      args: [lint]
-      language: python
-      types: [python]
-      require_serial: true
-      additional_dependencies: [
-          "flake8~=4.0",  # Don't upgrade, because flake8 5.0 is incompatible with flakeheaven
-          "flakeheaven==3.0.0",
-          "flake8-builtins",
-          "flake8-blind-except",
-          "flake8-logging-format",
-          "flake8-bugbear",
-          "flake8-annotations",
-          "flake8-docstrings",
-          "flake8-bandit",
-      ]
-- repo: https://github.com/doublify/pre-commit-rust
-  rev: v1.0
-  hooks:
-   - id: fmt
-   - id: clippy
-     args:
-       - --release
-       - --
-       - -D
-       - warnings
-- repo: https://github.com/nbQA-dev/nbQA
-  rev: 1.5.3
-  hooks:
-    - id: nbqa-isort
-    - id: nbqa-black
+  - id: black
+    language_version: python3.9
+-   repo: https://github.com/doublify/pre-commit-rust
+    rev: v1.0
+    hooks:
+    -   id: fmt
+    -   id: cargo-check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
   rev: 23.3.0
   hooks:
   - id: black
-    language_version: python3.9
+    language_version: python3
 -   repo: https://github.com/doublify/pre-commit-rust
     rev: v1.0
     hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ python -m pip install --upgrade pip maturin
 maturin develop --release --extras dev,docs,scylladb
 ```
 
-In the project [Task](https://taskfile.dev/) is used to organize tasks like formatting, linting, testing and more. Please install it separately in order to leverage the automation.
+In the project [Task](https://taskfile.dev/) is used to organize tasks like building, testing and more. Please install it separately in order to leverage the automation.
 Execute `task -l` to see the list of available commands.
 
 To install the pre-commit hooks:
@@ -63,9 +63,9 @@ work, tests, or other changes before your pull request can be ultimately accepte
 
 ### Python Code Style
 
-All Python code is linted with [Flake8](https://github.com/PyCQA/flake8) and formated with
+All Python code is linted with [Ruff](https://github.com/charliermarsh/ruff) and formatted with
 [Isort](https://github.com/PyCQA/isort) and [Black](https://github.com/psf/black). You can
-execute `inv[oke] lint` and `inv[oke] format`.
+execute `pre-commit run --all-files` to run the tools.
 
 ## Deploying
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -121,35 +121,6 @@ tasks:
       - "isort {{.PYTHON_TARGETS_SPACE_SEPARATED}}"
       - "black --quiet {{.PYTHON_TARGETS_SPACE_SEPARATED}}"
 
-  flake8:
-    desc: "Run flake8."
-    cmds:
-      - "flakeheaven lint  {{.PYTHON_TARGETS_SPACE_SEPARATED}}"
-
-  safety:
-    desc: "Run safety."
-    cmds:
-      - "poetry export --dev --format=requirements.txt --without-hashes | safety check --stdin --full-report"
-
-  mypy:
-    desc: "Run mypy."
-    cmds:
-      - "mypy --config-file pyproject.toml {{.SOURCE_DIR}}"
-
-  pylint:
-    desc: "Run pylint."
-    cmds:
-      - "pylint {{.PYTHON_TARGETS_SPACE_SEPARATED}}"
-
-  lint:
-    desc: Run all linters.
-    deps:
-      - check-format
-      - flake8
-      - safety
-      - mypy
-      - pylint
-
   #################
   ## Testing
   #################
@@ -201,7 +172,6 @@ tasks:
     desc: Run all checks together.
     deps:
       - hooks
-      - lint
       - pytest
       - coverage
       - doctest

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -121,6 +121,16 @@ tasks:
       - "isort {{.PYTHON_TARGETS_SPACE_SEPARATED}}"
       - "black --quiet {{.PYTHON_TARGETS_SPACE_SEPARATED}}"
 
+  mypy:
+    desc: "Run mypy."
+    cmds:
+      - "mypy --config-file pyproject.toml {{.SOURCE_DIR}}"
+
+  lint:
+    desc: Run all linters.
+    deps:
+      - mypy
+
   #################
   ## Testing
   #################

--- a/narrow_down/__init__.py
+++ b/narrow_down/__init__.py
@@ -4,4 +4,4 @@ __author__ = """Christian Krudewig"""
 __email__ = "chr1st1ank@krudewig-online.de"
 __version__ = "1.0.0"
 
-from . import hash, similarity_store, storage  # pylint: disable=redefined-builtin  # noqa
+from . import hash, similarity_store, storage  # pylint: disable=redefined-builtin

--- a/narrow_down/_minhash.py
+++ b/narrow_down/_minhash.py
@@ -209,7 +209,10 @@ class LSH:
     async def _query_documents(self, doc_ids: typing.List[int]):
         """Fetch a document from the storage and deserialize it."""
         docs = await self._storage.query_documents(doc_ids)
-        return [StoredDocument.deserialize(doc, doc_id) for doc, doc_id in zip(docs, doc_ids)]
+        return [
+            StoredDocument.deserialize(doc, doc_id)
+            for doc, doc_id in zip(docs, doc_ids)  # noqa=B905
+        ]
 
 
 def find_optimal_config(
@@ -217,9 +220,10 @@ def find_optimal_config(
 ) -> MinhashLshConfig:
     """Find the optimal configuration given the provided target parameters."""
     num_perm = 16
+    max_num_permutations = 16384
     b, r = _params_given_false_negative_proba(jaccard_threshold, num_perm, max_false_negative_proba)
     while _rust.false_positive_probability(jaccard_threshold, b, r) > max_false_positive_proba:
-        if num_perm >= 16384:
+        if num_perm >= max_num_permutations:
             warnings.warn("Unable to reach error thresholds. Taking the best value.", stacklevel=2)
             break
         num_perm *= 2

--- a/narrow_down/_tokenize.py
+++ b/narrow_down/_tokenize.py
@@ -22,7 +22,7 @@ def word_ngrams(s: str, n: int) -> Set[str]:
     words = s.split()
     if len(words) <= n:
         return {" ".join(words)}
-    return set(" ".join(words[i : i + n]) for i in range(len(words) - n + 1))
+    return {" ".join(words[i : i + n]) for i in range(len(words) - n + 1)}
 
 
 def char_ngrams(s: str, n: int, pad_char: str = "$") -> Set[str]:

--- a/narrow_down/proto/__init__.py
+++ b/narrow_down/proto/__init__.py
@@ -1,0 +1,1 @@
+"""Generated protobuf types."""

--- a/narrow_down/proto/stored_document_pb2.py
+++ b/narrow_down/proto/stored_document_pb2.py
@@ -31,7 +31,6 @@ StoredDocumentProto = _reflection.GeneratedProtocolMessageType(
 _sym_db.RegisterMessage(StoredDocumentProto)
 
 if _descriptor._USE_C_DESCRIPTORS == False:
-
     DESCRIPTOR._options = None
     _STOREDDOCUMENTPROTO._serialized_start = 49
     _STOREDDOCUMENTPROTO._serialized_end = 221

--- a/narrow_down/scylladb.py
+++ b/narrow_down/scylladb.py
@@ -27,7 +27,7 @@ def _wrap_future(f: cassandra.cluster.ResponseFuture):
 
     Returns:
         And asyncio.Future object which can be awaited.
-    """  # noqa: E501
+    """
     loop = asyncio.get_event_loop()
     aio_future = loop.create_future()
 
@@ -186,7 +186,7 @@ class ScyllaDBStore(StorageBackend):
 
         Raises:
             cassandra.DriverException: In case the database query fails for any reason.
-        """  # noqa: DAR401 # pylint: disable=missing-raises-doc
+        """  # pylint: disable=missing-raises-doc
         with self._session() as session:
             try:
                 result_list = await self._execute(
@@ -210,7 +210,7 @@ class ScyllaDBStore(StorageBackend):
                 return document_id
             else:
                 for _ in range(10):
-                    doc_id = random.randint(a=0, b=2**32)
+                    doc_id = random.randint(a=0, b=2**32)  # noqa=S311
                     result = await self._execute(
                         session,
                         self._prepared_statements["set_doc_checked"],

--- a/narrow_down/similarity_store.py
+++ b/narrow_down/similarity_store.py
@@ -281,7 +281,8 @@ class SimilarityStore:
             c
             for jaccard, c in sorted(
                 filter(
-                    lambda t: t[0] >= self._similarity_threshold, zip(true_jaccards, candidates)
+                    lambda t: t[0] >= self._similarity_threshold,
+                    zip(true_jaccards, candidates),  # noqa=B905
                 ),
                 key=lambda t: (t[0], t[1].id_ or 0),
                 reverse=True,

--- a/narrow_down/sqlite.py
+++ b/narrow_down/sqlite.py
@@ -154,7 +154,7 @@ class SQLiteStore(StorageBackend):
         partition = int(document_hash % self.partitions)
         with self._connection as conn:
             conn.execute(
-                f"INSERT INTO buckets_{partition}(bucket,hash,doc_id) VALUES (?,?,?)",  # noqa: S608
+                f"INSERT INTO buckets_{partition}(bucket,hash,doc_id) VALUES (?,?,?)",
                 (bucket_id, document_hash, document_id),
             )
 
@@ -162,7 +162,7 @@ class SQLiteStore(StorageBackend):
         """Get all document IDs stored in a bucket for a certain hash value."""
         partition = int(document_hash % self.partitions)
         cursor = self._connection.execute(
-            f"SELECT doc_id FROM buckets_{partition} WHERE bucket=? AND hash=?",  # noqa: S608
+            f"SELECT doc_id FROM buckets_{partition} WHERE bucket=? AND hash=?",
             (bucket_id, document_hash),
         )
         return [r[0] for r in cursor.fetchall()]
@@ -172,7 +172,6 @@ class SQLiteStore(StorageBackend):
         with self._connection as conn:
             partition = int(document_hash % self.partitions)
             conn.execute(
-                f"DELETE FROM buckets_{partition} "  # noqa: S608
-                "WHERE bucket=? AND hash=? AND doc_id=?",
+                f"DELETE FROM buckets_{partition} " "WHERE bucket=? AND hash=? AND doc_id=?",
                 (bucket_id, document_hash, document_id),
             )

--- a/narrow_down/storage.py
+++ b/narrow_down/storage.py
@@ -14,7 +14,7 @@ from narrow_down.proto.stored_document_pb2 import StoredDocumentProto
 from ._rust import RustMemoryStore
 
 
-class TooLowStorageLevel(Exception):
+class TooLowStorageLevel(Exception):  # noqa=N818
     """Raised if a feature is used for which a higher storage level is needed."""
 
 
@@ -132,7 +132,7 @@ class StorageBackend(ABC):
         Returns:
             A string with the value. If the key does not exist or the storage is uninitialized
             None is returned.
-        """  # noqa: DAR202,DAR401
+        """
         raise NotImplementedError
 
     @abstractmethod
@@ -152,7 +152,7 @@ class StorageBackend(ABC):
 
         Raises:
             KeyError: If no document with the given ID is stored.
-        """  # noqa: DAR202,DAR401
+        """
         raise NotImplementedError
 
     async def query_documents(self, document_ids: List[int]) -> List[bytes]:
@@ -166,7 +166,7 @@ class StorageBackend(ABC):
 
         Raises:
             KeyError: If no document was found for at least one of the ids.
-        """  # noqa: DAR401
+        """
         # Standard implementation of the base class. May be overloaded for specialization.
         return await asyncio.gather(*[self.query_document(doc_id) for doc_id in document_ids])
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -53,13 +53,6 @@ def tests(session: Session) -> None:
             session.notify("coverage")
 
 
-@nox.session(python="3.10")
-def safety(session: Session) -> None:
-    """Scan dependencies for insecure packages."""
-    install_with_constraints(session, "safety")
-    session.run("task", "safety")
-
-
 @nox.session(python=python_versions)
 def benchmarks(session: Session) -> None:
     """Produce the coverage report."""

--- a/noxfile.py
+++ b/noxfile.py
@@ -8,7 +8,7 @@ nox.options.sessions = ["tests", "benchmarks"]
 python_versions = ["3.7", "3.8", "3.9", "3.10"]
 
 
-def install_with_constraints(session: Session, *args: str) -> None:  # noqa
+def install_with_constraints(session: Session, *args: str) -> None:
     """Install packages constrained by Poetry's lock file.
 
     This function is a wrapper for nox.sessions.Session.install. It

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,26 +52,14 @@ docs = [
 ]
 dev = [
     "pre-commit",
-    "flake8~=4.0",  # Don't upgrade, because flake8 5.0 is incompatible with flakeheaven
-    "flakeheaven==3.2.1",
-    "flake8-builtins",
-    "flake8-blind-except",
-    "flake8-logging-format",
-    "flake8-bugbear",
-    "flake8-annotations",
-    "flake8-docstrings",
-    "flake8-bandit",
-    "darglint",
     "isort",
     "black",
-    "safety",
     "jupyter",
     "nbqa",
     "nox",
     "mypy",
     "mypy-protobuf",
     "nbmake",
-    "pylint",
     "bump2version",
     "pytest",
     "pytest-asyncio",
@@ -116,60 +104,6 @@ show_missing = true
 [tool.coverage.html]
 directory = "htmlcov"
 
-[tool.flakeheaven]
-format = "grouped"
-max_line_length = 100
-show_source = true
-docstring-convention = "google"
-exclude = ["*/proto/*.py"]
-
-[tool.flakeheaven.plugins]
-pyflakes = ["+*"]
-mccabe = ["+*"]
-"flake8-*" = [
-    "+*",
-]
-
-flake8-annotations = [
-    "-ANN101",  # Missing type annotation for self in method
-    "-ANN102",   # Missing type annotation for cls in classmethod
-    "-DAR402",    # Excess exception(s) in Raises section; Clashes with unhandled inner exceptions
-]
-flake8-bandit = [
-    "-S311"  # Standard pseudo-random generators are not suitable for cryptographic purposes.
-]
-flake8-darglint = [
-    "+*",
-    "-DAR402",    # Excess exception(s) in Raises section; Clashes with unhandled inner exceptions
-]
-pycodestyle = [
-    "+*",
-    "-E203",  # whitespace before ‘:’, conflict with black
-    "-E266",  # Comments with multiple ##
-    "-W503",  # Line breaks before binary operators. Sometimes clashes with black
-    "-W504",  # Line breaks after binary operators. These are preferred according to PEP8
-]
-
-[tool.flakeheaven.exceptions."narrow_down/proto/*.py"]
-"flake8-*" = ["-*"]
-pycodestyle = ["-*"]
-
-[tool.flakeheaven.exceptions."tests/test_*.py"]  # Allow more sloppy styling in tests
-flake8 = [
-    "-W291"     # Trailing whitespace. Often appears in multiline strings in tests
-]
-flake8-annotations = [
-    "-ANN001",  # Missing type annotation for function argument
-    "-ANN201",  # Missing return type annotation for public function
-    "-ANN102"   # Missing type annotation for cls in classmethod
-]
-flake8-bandit = [
-    "-S101",  # Assert used
-]
-flake8-docstrings = [
-    "-D103",    # Missing docstring in public function"
-]
-
 [tool.isort]
 multi_line_output = 3
 include_trailing_comma = true
@@ -196,56 +130,6 @@ exclude = '''
   | dist
 )/mypy
 '''
-
-[tool.pylint.master]
-ignore = ["tests"]
-reports = false
-extension-pkg-allow-list="cassandra,numpy,narrow_down"
-load-plugins = [
-    "pylint.extensions.docparams", # Find parameters missing in docstrings
-    "pylint.extensions.docstyle", # Detect wrong docstring formatting
-]
-disable = [
-    "invalid-name", # Creates warnings for local single-letter variables
-    "fixme", # fixme; Creates warnings for todo items
-    "no-else-return", # Creates refactor result for indented else block; which however might be more readable
-    "duplicate-code", # Unfortunately this gives alerts also for identical function signatures
-    "line-too-long", # Checked already by flake8
-    "c-extension-no-member",
-    "invalid-name",
-    "no-else-return",
-    "line-too-long",
-    "abstract-class-instantiated",
-]
-
-[tool.pylint.design]
-max-args = 10  # Maximum number of arguments for functions
-max-attributes = 15  # Maximum number of attributes for a class
-
-
-[tool.pylint.TESTING]
-ignore = ["narrow_down"]
-reports = false
-extension-pkg-allow-list="cassandra,numpy,narrow_down"
-load-plugins = [
-    "pylint.extensions.docparams", # Find parameters missing in docstrings
-    "pylint.extensions.docstyle", # Detect wrong docstring formatting
-]
-disable = [
-    "C",
-    "redefined-outer-name",
-    "protected-access",
-    "invalid-name", # Creates warnings for local single-letter variables
-    "fixme", # fixme; Creates warnings for todo items
-    "no-else-return", # Creates refactor result for indented else block; which however might be more readable
-    "duplicate-code", # Unfortunately this gives alerts also for identical function signatures
-    "line-too-long", # Checked already by flake8
-    "c-extension-no-member",
-    "invalid-name",
-    "no-else-return",
-    "line-too-long",
-    "abstract-class-instantiated",
-]
 
 [tool.mypy]
 follow_imports = "silent"

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,39 @@
+line-length = 100
+extend-exclude = ["*.ipynb", "**/*_pb2.py", "**/*_pb2.pyi"]
+select = [
+    "A",  # flake8-builtins
+    "C4",  # flake8-comprehensions
+    "DTZ",  # flake8-datetimez
+    "B",
+    "B9",
+    "C",
+    "G",  # flake8-logging-format
+    "PYI",  # flake8-pyi
+    "PT",  # flake8-pytest-style
+    "TCH",  #  flake8-type-checking
+    "C90",  # MCCabe
+    "D",  # Pydocstyle
+    "E",  # Pycodestyle error
+    "F",  # Pyflakes
+    "I",  # Isort
+    "N",  # pep8-naming
+    "W",  # Pycodestyle warning
+#    "ANN",  # flake8-annotations
+    "S",  # flake8-bandit
+    "BLE",  # flake8-blind-except
+    "PD",  # pandas-vet
+    "PL",  # Pylint
+    "RUF",  # Ruff
+]
+ignore = ["C408", "PLR0913", "S608", "PYI021"]
+
+[mccabe]
+max-complexity = 18
+
+[pydocstyle]
+convention = "google"
+
+[per-file-ignores]
+"__init__.py" = ["F401"]
+"tests/*" = ["ANN", "D", "S101", "PT", "PLR", "PD901", "RUF001"]
+"integration_tests/*" = ["ANN", "D", "S101", "PT", "PLR", "PD901", "RUF001"]

--- a/tests/test_scylladb.py
+++ b/tests/test_scylladb.py
@@ -157,7 +157,7 @@ def session_mock(request, scylladb_cluster, table_prefix):
     keyspace_name = (
         request.node.name[-20 : request.node.name.find("[")]
         + "_"
-        + hashlib.md5(request.node.name.encode("utf-8")).hexdigest()[-4:]
+        + hashlib.md5(request.node.name.encode("utf-8")).hexdigest()[-4:]  # noqa=S324
     ).lstrip("_")
     if scylladb_cluster:
         print("USING KEYSPACE", keyspace_name)
@@ -429,7 +429,7 @@ async def test_scylladb_store__query_documents(session_mock):
     storage = await narrow_down.scylladb.ScyllaDBStore(
         session_mock, session_mock.test_keyspace, session_mock.table_prefix
     ).initialize()
-    for doc_id, doc_val in zip(doc_ids, doc_vals):
+    for doc_id, doc_val in zip(doc_ids, doc_vals):  # noqa=B905
         session_mock.add_mock_response(
             "INSERT INTO <keyspace>.<table_prefix>documents(id,doc) "
             f"VALUES ({doc_id},{doc_val});",
@@ -440,12 +440,15 @@ async def test_scylladb_store__query_documents(session_mock):
     session_mock.add_mock_response(
         f"select id, doc from <keyspace>.<table_prefix>documents where id IN "
         f"({','.join(map(str,doc_ids[:50]))});",
-        [row(id=i, doc=doc_val) for i, doc_val in zip(doc_ids[:50], doc_vals[:50])],
+        [row(id=i, doc=doc_val) for i, doc_val in zip(doc_ids[:50], doc_vals[:50])],  # noqa=B905
     )
     session_mock.add_mock_response(
         f"select id, doc from <keyspace>.<table_prefix>documents where id IN "
         f"({','.join(map(str,doc_ids[50:100]))});",
-        [row(id=i, doc=doc_val) for i, doc_val in zip(doc_ids[50:100], doc_vals[50:100])],
+        [
+            row(id=i, doc=doc_val)
+            for i, doc_val in zip(doc_ids[50:100], doc_vals[50:100])  # noqa=B905
+        ],
     )
 
     assert await storage.query_documents(doc_ids) == doc_vals


### PR DESCRIPTION
- Handle all ruff warnings
- Remove flake8 (the warnings are covered by ruff)
- Remove safety: It turns out that it has a strict licensing on their databases and that the open db is with outdated data anyway